### PR TITLE
Update to French UI with transcription display

### DIFF
--- a/suggester.py
+++ b/suggester.py
@@ -32,11 +32,12 @@ class RecipeSuggester:
         ingr = ", ".join(ingredients) if ingredients else "none"
         utn = ", ".join(utensils) if utensils else "none"
         return (
-            "You are a helpful cooking assistant. "
-            f"The user can use these base ingredients: {ingr}. "
-            f"Available utensils: {utn}. "
-            f"User request: {request_text}. "
-            "Suggest a recipe that fits the request, taking into account the available ingredients and utensils."
+            "Tu es un assistant culinaire serviable. "
+            f"L'utilisateur peut utiliser ces ingrédients de base : {ingr}. "
+            f"Ustensiles disponibles : {utn}. "
+            f"Demande de l'utilisateur : {request_text}. "
+            "Suggère une recette adaptée en prenant en compte les ingrédients et ustensiles disponibles. "
+            "Réponds uniquement en français."
         )
 
     def suggest_recipe(self, request_text: str) -> str:


### PR DESCRIPTION
## Summary
- translate interface to French and set default language
- show speech-to-text transcription directly after recording
- collapse ingredient and utensil editors in new expanders
- ensure recipe suggestions are provided in French

## Testing
- `python -m py_compile app.py suggester.py`

------
https://chatgpt.com/codex/tasks/task_e_684b2da99a98833081f40c5c52579b7e